### PR TITLE
fix for apt lock

### DIFF
--- a/spotty/commands/delete_ami.py
+++ b/spotty/commands/delete_ami.py
@@ -32,7 +32,7 @@ class DeleteAmiCommand(AbstractConfigCommand):
 
         # check that only one image with such name exists
         if not len(res['Images']):
-            raise ValueError('Image with Name=%s not found.' % ami_name)
+            raise ValueError('AMI with name "%s" not found.' % ami_name)
         elif len(res['Images']) > 1:
             raise ValueError('Several images with Name=%s found.' % ami_name)
 

--- a/spotty/data/create_ami.yaml
+++ b/spotty/data/create_ami.yaml
@@ -101,6 +101,10 @@ Resources:
           'Fn::Base64': !Sub |
             #!/bin/bash -x
 
+            # stop daily updates for apt (fix for the issue when the cloud-init fails to install packages
+            # because the "/var/lib/dpkg/lock" file is locked)
+            systemctl disable --now apt-daily{,-upgrade}.{timer,service}
+
             # install CloudFormation tools
             apt-get update
             apt-get -y install python-setuptools
@@ -248,6 +252,12 @@ Resources:
                 file = /var/log/cfn-init.log
                 log_group_name = ${InstanceLogGroup}
                 log_stream_name = {instance_id}/cfn-init.log
+                datetime_format = %d/%b/%Y:%H:%M:%S
+
+                [/var/log/cfn-init-cmd.log]
+                file = /var/log/cfn-init-cmd.log
+                log_group_name = ${InstanceLogGroup}
+                log_stream_name = {instance_id}/cfn-init-cmd.log
                 datetime_format = %d/%b/%Y:%H:%M:%S
               mode: '000400'
               owner: root

--- a/spotty/data/run_container.yaml
+++ b/spotty/data/run_container.yaml
@@ -135,6 +135,12 @@ Resources:
                 log_stream_name = {instance_id}/cfn-init.log
                 datetime_format = %d/%b/%Y:%H:%M:%S
 
+                [/var/log/cfn-init-cmd.log]
+                file = /var/log/cfn-init-cmd.log
+                log_group_name = ${InstanceLogGroup}
+                log_stream_name = {instance_id}/cfn-init-cmd.log
+                datetime_format = %d/%b/%Y:%H:%M:%S
+
                 [/var/log/cfn-hup.log]
                 file = /var/log/cfn-hup.log
                 log_group_name = ${SpotInstanceLogGroup}
@@ -184,7 +190,7 @@ Resources:
                 mkdir -p /var/log/spotty-run
                 chmod 777 /var/log/spotty-run
           commands:
-            mount_volume:
+            prepare_instance:
               command: '/bin/bash -xe /tmp/scripts/prepare_instance.sh'
         mount_volumes_config:
           files:
@@ -221,7 +227,7 @@ Resources:
                   aws s3 sync s3://${ProjectS3Bucket}/project ${ProjectDirectory}
                 fi
           commands:
-            mount_volume:
+            sync_project:
               command: '/bin/bash -xe /tmp/scripts/sync_project.sh'
         docker_container_config:
           files:


### PR DESCRIPTION
stop daily updates for apt: fix for the issue when the cloud-init fails to install packages because the "/var/lib/dpkg/lock" file is locked