### PR TITLE
Add vpcId option to the instance configuration section

### DIFF
--- a/spotty/commands/ssh.py
+++ b/spotty/commands/ssh.py
@@ -29,6 +29,7 @@ class SshCommand(AbstractConfigCommand):
         parser.add_argument('--host-os', '-o', action='store_true', help='Connect to the host OS instead of the Docker '
                                                                          'container')
         parser.add_argument('--session-name', '-s', type=str, default=None, help='tmux session name')
+        parser.add_argument('--list-sessions', '-l', action='store_true', help='list running tmux sessions')
 
     def run(self, output: AbstractOutputWriter):
         project_config = self._config['project']
@@ -47,6 +48,8 @@ class SshCommand(AbstractConfigCommand):
             # connect to the host OS
             session_name = self._args.session_name if self._args.session_name else 'spotty-ssh-host-os'
             remote_cmd = ['tmux', 'new', '-s', session_name, '-A']
+        elif self._args.list_sessions:
+            remote_cmd = ['tmux', 'ls']
         else:
             # connect to the container
             session_name = self._args.session_name if self._args.session_name else 'spotty-ssh-container'

--- a/spotty/commands/start.py
+++ b/spotty/commands/start.py
@@ -30,6 +30,7 @@ class StartCommand(AbstractConfigCommand):
         region = instance_config['region']
         availability_zone = instance_config['availabilityZone']
         subnet_id = instance_config['subnetId']
+        vpc_id = instance_config.get('vpcId', '')
 
         cf = boto3.client('cloudformation', region_name=region)
         ec2 = boto3.client('ec2', region_name=region)
@@ -75,7 +76,7 @@ class StartCommand(AbstractConfigCommand):
 
         res = stack.create_stack(ec2, template, instance_profile_arn, instance_type, ami_name, root_volume_size,
                                  mount_dirs, bucket_name, remote_project_dir, project_name, self._project_dir,
-                                 docker_config)
+                                 docker_config, vpc_id)
 
         output.write('Waiting for the stack to be created...')
 

--- a/spotty/helpers/validation.py
+++ b/spotty/helpers/validation.py
@@ -37,6 +37,7 @@ def validate_instance_config(data):
         'instance': {
             'region': And(str, len),
             Optional('availabilityZone', default=''): str,
+            Optional('vpcId', default=''): str,
             Optional('subnetId', default=''): str,
             'instanceType': And(str, And(is_valid_instance_type, error='Invalid instance type.')),
             Optional('onDemandInstance', default=False): bool,

--- a/spotty/project_resources/stack.py
+++ b/spotty/project_resources/stack.py
@@ -150,9 +150,10 @@ class StackResource(object):
         # get default VPC ID if one is not specified
         if not vpc_id:
             vpc_query_args= {'Filters': [{'Name': 'isDefault', 'Values': ['true']}]}
+        # botocore.exceptions.ClientError (InvalidVpcID.NotFound) will be raised if incorrect VPC ID is specified.
         res = ec2.describe_vpcs(**vpc_query_args)
         if not len(res['Vpcs']):
-            raise ValueError( 'VPC %s not found' % (vpc_id) if vpc_id else 'Default VPC not found')
+            raise ValueError('Default VPC not found')
 
         vpc_id = res['Vpcs'][0]['VpcId']
 

--- a/spotty/project_resources/stack.py
+++ b/spotty/project_resources/stack.py
@@ -146,13 +146,15 @@ class StackResource(object):
                      project_name: str, project_dir: str, docker_config: dict, vpc_id: str):
         """Runs CloudFormation template."""
 
+        vpc_query_args = {'VpcIds': [vpc_id]}
         # get default VPC ID if one is not specified
         if not vpc_id:
-            res = ec2.describe_vpcs(Filters=[{'Name': 'isDefault', 'Values': ['true']}])
-            if not len(res['Vpcs']):
-                raise ValueError('Default VPC not found')
+            vpc_query_args= {'Filters': [{'Name': 'isDefault', 'Values': ['true']}]}
+        res = ec2.describe_vpcs(**vpc_query_args)
+        if not len(res['Vpcs']):
+            raise ValueError( 'VPC %s not found' % (vpc_id) if vpc_id else 'Default VPC not found')
 
-            vpc_id = res['Vpcs'][0]['VpcId']
+        vpc_id = res['Vpcs'][0]['VpcId']
 
         # get image info
         ami_info = get_ami(ec2, ami_name)

--- a/spotty/project_resources/stack.py
+++ b/spotty/project_resources/stack.py
@@ -143,15 +143,16 @@ class StackResource(object):
 
     def create_stack(self, ec2, template: str, instance_profile_arn: str, instance_type: str, ami_name: str,
                      root_volume_size: int, mount_dirs: list, bucket_name: str, remote_project_dir: str,
-                     project_name: str, project_dir: str, docker_config: dict):
+                     project_name: str, project_dir: str, docker_config: dict, vpc_id: str):
         """Runs CloudFormation template."""
 
-        # get default VPC ID
-        res = ec2.describe_vpcs(Filters=[{'Name': 'isDefault', 'Values': ['true']}])
-        if not len(res['Vpcs']):
-            raise ValueError('Default VPC not found')
+        # get default VPC ID if one is not specified
+        if not vpc_id:
+            res = ec2.describe_vpcs(Filters=[{'Name': 'isDefault', 'Values': ['true']}])
+            if not len(res['Vpcs']):
+                raise ValueError('Default VPC not found')
 
-        vpc_id = res['Vpcs'][0]['VpcId']
+            vpc_id = res['Vpcs'][0]['VpcId']
 
         # get image info
         ami_info = get_ami(ec2, ami_name)


### PR DESCRIPTION
Allows to specify an exact VPC ID (e.g. if the default one is deleted).

Also added a command line option "spotty ssh -l" to list currently running tmux sessions, useful when a connection to "spotty run [scriptname]" is broken and one needs to reconnect to the running session by its name.

If the PR is merged please add the new option to the wiki https://github.com/apls777/spotty/wiki/Configuration-File :
**vpcId** (optional) - AWS VPC where to run an instance. If VPC ID is not specified, the default one will be used.