### PR TITLE
Fix bootDiskSize for gcp

### DIFF
--- a/spotty/providers/gcp/deployment/dm_templates/instance/template.yaml
+++ b/spotty/providers/gcp/deployment/dm_templates/instance/template.yaml
@@ -23,6 +23,7 @@ resources:
           autoDelete: true
           initializeParams:
             sourceImage: {{SOURCE_IMAGE}}
+            diskSizeGb: {{BOOT_DISK_SIZE}}
 
         {{#DISK_ATTACHMENTS}}
         - source: {{DISK_LINK}}

--- a/spotty/providers/gcp/deployment/dm_templates/instance_template.py
+++ b/spotty/providers/gcp/deployment/dm_templates/instance_template.py
@@ -53,6 +53,7 @@ def prepare_instance_template(instance_config: InstanceConfig, container: Contai
         'ZONE': instance_config.zone,
         'MACHINE_TYPE': instance_config.machine_type,
         'SOURCE_IMAGE': image_link,
+        'BOOT_DISK_SIZE': str(instance_config.boot_disk_size) if instance_config.boot_disk_size else '10',
         'STARTUP_SCRIPT': fix_indents_for_lines(startup_script, template, '{{{STARTUP_SCRIPT}}}'),
         'MACHINE_NAME': machine_name,
         'PREEMPTIBLE': 'false' if instance_config.on_demand else 'true',


### PR DESCRIPTION
bootDiskSize in the configuration file didn't work for gcp in my case, so I did a small fix.