### PR TITLE
Enabling the use of AWS gp3 volume for Spotty

### DIFF
--- a/spotty/deployment/container/docker/docker_commands.py
+++ b/spotty/deployment/container/docker/docker_commands.py
@@ -12,7 +12,7 @@ class DockerCommands(AbstractContainerCommands):
         if not self._instance_config.docker_context_path:
             raise ValueError('Cannot generate the "build" command as Docker context path is not set')
 
-        build_cmd = 'docker build -t %s -f %s %s' % (image_name, shlex.quote(self._instance_config.dockerfile_path),
+        build_cmd = 'DOCKER_BUILDKIT=1 docker build -t %s -f %s %s' % (image_name, shlex.quote(self._instance_config.dockerfile_path),
                                                      shlex.quote(self._instance_config.docker_context_path))
 
         if self._instance_config.container_config.run_as_host_user:

--- a/spotty/deployment/container/docker/docker_commands.py
+++ b/spotty/deployment/container/docker/docker_commands.py
@@ -12,7 +12,7 @@ class DockerCommands(AbstractContainerCommands):
         if not self._instance_config.docker_context_path:
             raise ValueError('Cannot generate the "build" command as Docker context path is not set')
 
-        build_cmd = 'DOCKER_BUILDKIT=1 docker build -t %s -f %s %s' % (image_name, shlex.quote(self._instance_config.dockerfile_path),
+        build_cmd = 'docker build -t %s -f %s %s' % (image_name, shlex.quote(self._instance_config.dockerfile_path),
                                                      shlex.quote(self._instance_config.docker_context_path))
 
         if self._instance_config.container_config.run_as_host_user:

--- a/spotty/providers/aws/config/validation.py
+++ b/spotty/providers/aws/config/validation.py
@@ -70,7 +70,7 @@ def validate_ebs_volume_parameters(params: dict):
         ),
         Optional('size', default=0): And(int, lambda x: x > 0),
         # TODO: add the "iops" parameter to support the "io1" EBS volume type
-        Optional('type', default='gp2'): lambda x: x in ['gp2', 'sc1', 'st1', 'standard'],
+        Optional('type', default='gp2'): lambda x: x in ['gp3', 'gp2', 'sc1', 'st1', 'standard'],
         Optional('deletionPolicy', default=EbsVolume.DP_RETAIN): And(
             str,
             lambda x: x in [EbsVolume.DP_CREATE_SNAPSHOT,


### PR DESCRIPTION
Adding gp3 volume type as acceptable as volume type for Spotty launch procedure.

gp3 is designed to provide predictable 3,000 IOPS baseline performance and 125 MiB/s regardless of volume size.